### PR TITLE
Use strconv.FormatInt instead of fmt.Sprintf

### DIFF
--- a/middleware_gjr.go
+++ b/middleware_gjr.go
@@ -1,7 +1,7 @@
 package limiter
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/ant0ine/go-json-rest/rest"
 )
@@ -26,9 +26,9 @@ func (m *GJRMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFunc {
 			panic(err)
 		}
 
-		w.Header().Add("X-RateLimit-Limit", fmt.Sprintf("%d", context.Limit))
-		w.Header().Add("X-RateLimit-Remaining", fmt.Sprintf("%d", context.Remaining))
-		w.Header().Add("X-RateLimit-Reset", fmt.Sprintf("%d", context.Reset))
+		w.Header().Add("X-RateLimit-Limit", strconv.FormatInt(context.Limit, 10))
+		w.Header().Add("X-RateLimit-Remaining", strconv.FormatInt(context.Remaining, 10))
+		w.Header().Add("X-RateLimit-Reset", strconv.FormatInt(context.Reset, 10))
 
 		// That can be useful to access rate limit context in views.
 		r.Env["ratelimit:limit"] = context.Limit

--- a/middleware_http.go
+++ b/middleware_http.go
@@ -2,8 +2,8 @@ package limiter
 
 // HTTPMiddleware is the middleware for basic http.Handler.
 import (
-	"fmt"
 	"net/http"
+	"strconv"
 )
 
 // HTTPMiddleware is the basic HTTP middleware.
@@ -24,9 +24,9 @@ func (m *HTTPMiddleware) Handler(h http.Handler) http.Handler {
 			panic(err)
 		}
 
-		w.Header().Add("X-RateLimit-Limit", fmt.Sprintf("%d", context.Limit))
-		w.Header().Add("X-RateLimit-Remaining", fmt.Sprintf("%d", context.Remaining))
-		w.Header().Add("X-RateLimit-Reset", fmt.Sprintf("%d", context.Reset))
+		w.Header().Add("X-RateLimit-Limit", strconv.FormatInt(context.Limit, 10))
+		w.Header().Add("X-RateLimit-Remaining", strconv.FormatInt(context.Remaining, 10))
+		w.Header().Add("X-RateLimit-Reset", strconv.FormatInt(context.Reset, 10))
 
 		if context.Reached {
 			http.Error(w, "Limit exceeded", 429)


### PR DESCRIPTION
If we are rate limiting something, presumably it is a high traffic site, so performance matters.

Every little bit helps, so we can use strconv.FormatInt instead of fmt.Sprintf when attaching the HTTP headers.

Benchmark to see why: https://gist.github.com/evalphobia/caee1602969a640a4530