### PR TITLE
Add an option to customize the rate limiter key in gin middleware

### DIFF
--- a/drivers/middleware/gin/middleware.go
+++ b/drivers/middleware/gin/middleware.go
@@ -13,6 +13,7 @@ type Middleware struct {
 	Limiter        *limiter.Limiter
 	OnError        ErrorHandler
 	OnLimitReached LimitReachedHandler
+	KeyGetter      KeyGetter
 }
 
 // NewMiddleware return a new instance of a basic HTTP middleware.
@@ -21,6 +22,7 @@ func NewMiddleware(limiter *limiter.Limiter, options ...Option) gin.HandlerFunc 
 		Limiter:        limiter,
 		OnError:        DefaultErrorHandler,
 		OnLimitReached: DefaultLimitReachedHandler,
+		KeyGetter:      DefaultKeyGetter,
 	}
 
 	for _, option := range options {
@@ -34,7 +36,8 @@ func NewMiddleware(limiter *limiter.Limiter, options ...Option) gin.HandlerFunc 
 
 // Handle gin request.
 func (middleware *Middleware) Handle(c *gin.Context) {
-	context, err := middleware.Limiter.Get(c, c.ClientIP())
+	key := middleware.KeyGetter(c)
+	context, err := middleware.Limiter.Get(c, key)
 	if err != nil {
 		middleware.OnError(c, err)
 		c.Abort()

--- a/drivers/middleware/gin/options.go
+++ b/drivers/middleware/gin/options.go
@@ -46,3 +46,19 @@ func WithLimitReachedHandler(handler LimitReachedHandler) Option {
 func DefaultLimitReachedHandler(c *gin.Context) {
 	c.String(http.StatusTooManyRequests, "Limit exceeded")
 }
+
+// KeyGetter will define the rate limiter key given the gin Context
+type KeyGetter func(c *gin.Context) string
+
+// WithKeyGetter will configure the Middleware to use the given KeyGetter
+func WithKeyGetter(KeyGetter KeyGetter) Option {
+	return option(func(middleware *Middleware) {
+		middleware.KeyGetter = KeyGetter
+	})
+}
+
+// DefaultKeyGetter is the default KeyGetter used by a new Middleware
+// It returns the Client IP address
+func DefaultKeyGetter(c *gin.Context) string {
+	return c.ClientIP()
+}


### PR DESCRIPTION
The user of the library can set the way the rate limiter key is
computed by passing a function taking the gin context as input.
We keep the current behavior by default by providing a function
returning the Client IP address as a default key getter.