### PR TITLE
Use the DefaultMaxRetry for defaulting MaxRetry

### DIFF
--- a/drivers/store/redis/store.go
+++ b/drivers/store/redis/store.go
@@ -38,6 +38,7 @@ func NewStore(client Client) (limiter.Store, error) {
 	return NewStoreWithOptions(client, limiter.StoreOptions{
 		Prefix:          limiter.DefaultPrefix,
 		CleanUpInterval: limiter.DefaultCleanUpInterval,
+		MaxRetry:        limiter.DefaultMaxRetry,
 	})
 }
 


### PR DESCRIPTION
Hi, I just came across this while using .NewStore(), and running into a 'retry limit exceeded' error. This just passes the DefaultMaxRetry in the NewStore call to NewStoreWithOptions. I left the lower line in NewStoreWithOptions in, in the event that someone sets DefaultMaxRetry to <=0 at some point.