### PR TITLE
Handle both redis response codes on PTTL

### DIFF
--- a/drivers/store/redis/store.go
+++ b/drivers/store/redis/store.go
@@ -230,8 +230,11 @@ func updateValue(rtx *libredis.Tx, key string, expiration time.Duration) (int64,
 		return 0, 0, err
 	}
 
-	// If ttl is negative, we have to define key expiration.
-	if ttl < 0 {
+	// If ttl is -1, we have to define key expiration.
+	// PTTL return values changed as of Redis 2.8
+	// Now the command returns -2 if the key does not exist, and -1 if the key exists, but there is no expiry set
+	// We shouldn't try to set an expiry on a key that doesn't exist
+	if ttl == -1 {
 		expire := rtx.Expire(key, expiration)
 
 		ok, err := expire.Result()


### PR DESCRIPTION
Hi! I've periodically come across `cannot configure timeout on key` errors being returned from this block of code, and I think I've narrowed it down to a race-condition in key presence when using `.Get` from multiple goroutines concurrently. It seems that in the odd case that that the ttl is set to `-2` (key doesn't exist) trying to `expire` that key returns `!ok` which I think could be avoided by checking if `ttl==-1` instead of `ttl<0`. This would help ensure that `expire` doesn't get called on a non-existant key. So far this has been working in my implementation but I'd like to know your thoughts @novln.

Thanks for taking the time to read this!

https://redis.io/commands/pttl