### PR TITLE
Allow to reset values on store

### DIFF
--- a/drivers/store/memory/cache.go
+++ b/drivers/store/memory/cache.go
@@ -151,13 +151,9 @@ func (cache *Cache) Clean() {
 // Reset changes the key's value and resets the expiration.
 func (cache *Cache) Reset(key string, duration time.Duration) (int64, time.Time) {
 	cache.mutex.Lock()
-	expiration := time.Now().Add(duration).UnixNano()
-	counter := Counter{
-		Value:      0,
-		Expiration: expiration,
-	}
-	cache.counters[key] = counter
+	delete(cache.counters, key)
 	cache.mutex.Unlock()
 
-	return value, time.Unix(0, expiration)
+	expiration := time.Now().Add(duration).UnixNano()
+	return 0, time.Unix(0, expiration)
 }

--- a/drivers/store/memory/cache.go
+++ b/drivers/store/memory/cache.go
@@ -147,3 +147,17 @@ func (cache *Cache) Clean() {
 	}
 	cache.mutex.Unlock()
 }
+
+// Reset changes the key's value and resets the expiration.
+func (cache *Cache) Reset(key string, duration time.Duration) (int64, time.Time) {
+	cache.mutex.Lock()
+	expiration := time.Now().Add(duration).UnixNano()
+	counter := Counter{
+		Value:      0,
+		Expiration: expiration,
+	}
+	cache.counters[key] = counter
+	cache.mutex.Unlock()
+
+	return value, time.Unix(0, expiration)
+}

--- a/drivers/store/memory/cache_test.go
+++ b/drivers/store/memory/cache_test.go
@@ -94,3 +94,27 @@ func TestCacheGet(t *testing.T) {
 	is.InEpsilon(deleted, expire.UnixNano(), epsilon)
 
 }
+
+func TestCacheReset(t *testing.T) {
+	is := require.New(t)
+
+	key := "foobar"
+	cache := memory.NewCache(10 * time.Nanosecond)
+	duration := 50 * time.Millisecond
+	deleted := time.Now().Add(duration).UnixNano()
+	epsilon := 0.001
+
+	x, expire := cache.Get(key, duration)
+	is.Equal(int64(0), x)
+	is.InEpsilon(deleted, expire.UnixNano(), epsilon)
+
+	x, expire = cache.Get(key, duration)
+	is.Equal(int64(1), x)
+
+	x, expire = cache.Reset(key, duration)
+	is.Equal(int64(0), x)
+
+	x, expire = cache.Get(key, duration)
+	is.Equal(int64(1), x)
+
+}

--- a/drivers/store/memory/cache_test.go
+++ b/drivers/store/memory/cache_test.go
@@ -108,13 +108,24 @@ func TestCacheReset(t *testing.T) {
 	is.Equal(int64(0), x)
 	is.InEpsilon(deleted, expire.UnixNano(), epsilon)
 
-	x, expire = cache.Get(key, duration)
+	x, expire = cache.Increment(key, 1, duration)
 	is.Equal(int64(1), x)
+	is.InEpsilon(deleted, expire.UnixNano(), epsilon)
+
+	x, expire = cache.Increment(key, 1, duration)
+	is.Equal(int64(2), x)
+	is.InEpsilon(deleted, expire.UnixNano(), epsilon)
 
 	x, expire = cache.Reset(key, duration)
 	is.Equal(int64(0), x)
+	is.InEpsilon(deleted, expire.UnixNano(), epsilon)
 
-	x, expire = cache.Get(key, duration)
+	x, expire = cache.Increment(key, 1, duration)
 	is.Equal(int64(1), x)
+	is.InEpsilon(deleted, expire.UnixNano(), epsilon)
+
+	x, expire = cache.Increment(key, 1, duration)
+	is.Equal(int64(2), x)
+	is.InEpsilon(deleted, expire.UnixNano(), epsilon)
 
 }

--- a/drivers/store/memory/store.go
+++ b/drivers/store/memory/store.go
@@ -56,7 +56,7 @@ func (store *Store) Peek(ctx context.Context, key string, rate limiter.Rate) (li
 }
 
 // Reset returns the limit for given identifier.
-func (store *Store) Reset(ctx context.Context, key string) (limiter.Context, error) {
+func (store *Store) Reset(ctx context.Context, key string, rate limiter.Rate) (limiter.Context, error) {
 	key = fmt.Sprintf("%s:%s", store.Prefix, key)
 	now := time.Now()
 

--- a/drivers/store/memory/store.go
+++ b/drivers/store/memory/store.go
@@ -54,3 +54,14 @@ func (store *Store) Peek(ctx context.Context, key string, rate limiter.Rate) (li
 	lctx := common.GetContextFromState(now, rate, expiration, count)
 	return lctx, nil
 }
+
+// Reset returns the limit for given identifier.
+func (store *Store) Reset(ctx context.Context, key string) (limiter.Context, error) {
+	key = fmt.Sprintf("%s:%s", store.Prefix, key)
+	now := time.Now()
+
+	count, expiration := store.cache.Reset(key, rate.Period)
+
+	lctx := common.GetContextFromState(now, rate, expiration, count)
+	return lctx, nil
+}

--- a/limiter.go
+++ b/limiter.go
@@ -53,3 +53,8 @@ func (limiter *Limiter) Get(ctx context.Context, key string) (Context, error) {
 func (limiter *Limiter) Peek(ctx context.Context, key string) (Context, error) {
 	return limiter.Store.Peek(ctx, key, limiter.Rate)
 }
+
+// Reset sets the limit for given identifier to zero.
+func (limiter *Limiter) Reset(ctx context.Context, key string) (Context, error) {
+	return limiter.Store.Reset(ctx, key, limiter.Rate)
+}

--- a/store.go
+++ b/store.go
@@ -11,6 +11,8 @@ type Store interface {
 	Get(ctx context.Context, key string, rate Rate) (Context, error)
 	// Peek returns the limit for given identifier, without modification on current values.
 	Peek(ctx context.Context, key string, rate Rate) (Context, error)
+	// Reset resets the limit to zero for given identifier.
+	Reset(ctx context.Context, key string4) (Context, error)
 }
 
 // StoreOptions are options for store.

--- a/store.go
+++ b/store.go
@@ -12,7 +12,7 @@ type Store interface {
 	// Peek returns the limit for given identifier, without modification on current values.
 	Peek(ctx context.Context, key string, rate Rate) (Context, error)
 	// Reset resets the limit to zero for given identifier.
-	Reset(ctx context.Context, key string4) (Context, error)
+	Reset(ctx context.Context, key string, rate Rate) (Context, error)
 }
 
 // StoreOptions are options for store.


### PR DESCRIPTION
This PR continues the work initiated by @PatWie with #56 

It closes this feature request (#33) by adding a reset operation on IP address.