### PR TITLE
Add excluded keys for stdlib and fasthttp middlewares

### DIFF
--- a/drivers/middleware/fasthttp/middleware_test.go
+++ b/drivers/middleware/fasthttp/middleware_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ulule/limiter/v3/drivers/store/memory"
 )
 
+// nolint: gocyclo
 func TestFasthttpMiddleware(t *testing.T) {
 	is := require.New(t)
 

--- a/drivers/middleware/fasthttp/middleware_test.go
+++ b/drivers/middleware/fasthttp/middleware_test.go
@@ -133,6 +133,49 @@ func TestFasthttpMiddleware(t *testing.T) {
 		is.NoError(err)
 		is.Equal(libfasthttp.StatusOK, resp.StatusCode(), strconv.FormatInt(i, 10))
 	}
+
+	//
+	// Test ExcludedKey
+	//
+
+	store = memory.NewStore()
+	is.NotZero(store)
+
+	counter = int64(0)
+	keyGetterHandler := func(c *libfasthttp.RequestCtx) string {
+		v := atomic.AddInt64(&counter, 1)
+		return strconv.FormatInt(v%2, 10)
+	}
+	excludedKeyHandler := func(key string) bool {
+		return key == "1"
+	}
+
+	middleware = fasthttp.NewMiddleware(limiter.New(store, rate),
+		fasthttp.WithKeyGetter(keyGetterHandler), fasthttp.WithExcludedKey(excludedKeyHandler))
+	is.NotZero(middleware)
+
+	requestHandler = func(ctx *libfasthttp.RequestCtx) {
+		switch string(ctx.Path()) {
+		case "/":
+			ctx.SetStatusCode(libfasthttp.StatusOK)
+			ctx.SetBodyString("hello")
+		}
+	}
+
+	success = 20
+	for i := int64(1); i <= clients; i++ {
+		resp := libfasthttp.AcquireResponse()
+		req := libfasthttp.AcquireRequest()
+		req.Header.SetHost("localhost:8081")
+		req.Header.SetRequestURI("/")
+		err := serve(middleware.Handle(requestHandler), req, resp)
+		is.NoError(err)
+		if i <= success || i%2 == 1 {
+			is.Equal(libfasthttp.StatusOK, resp.StatusCode(), strconv.FormatInt(i, 10))
+		} else {
+			is.Equal(libfasthttp.StatusTooManyRequests, resp.StatusCode(), strconv.FormatInt(i, 10))
+		}
+	}
 }
 
 func serve(handler libfasthttp.RequestHandler, req *libfasthttp.Request, res *libfasthttp.Response) error {

--- a/drivers/middleware/fasthttp/options.go
+++ b/drivers/middleware/fasthttp/options.go
@@ -61,3 +61,10 @@ func WithKeyGetter(KeyGetter KeyGetter) Option {
 func DefaultKeyGetter(ctx *fasthttp.RequestCtx) string {
 	return ctx.RemoteIP().String()
 }
+
+// WithExcludedKey will configure the Middleware to ignore key(s) using the given function.
+func WithExcludedKey(handler func(string) bool) Option {
+	return option(func(middleware *Middleware) {
+		middleware.ExcludedKey = handler
+	})
+}

--- a/drivers/middleware/gin/middleware.go
+++ b/drivers/middleware/gin/middleware.go
@@ -24,6 +24,7 @@ func NewMiddleware(limiter *limiter.Limiter, options ...Option) gin.HandlerFunc 
 		OnError:        DefaultErrorHandler,
 		OnLimitReached: DefaultLimitReachedHandler,
 		KeyGetter:      DefaultKeyGetter,
+		ExcludedKey:    nil,
 	}
 
 	for _, option := range options {

--- a/drivers/middleware/gin/options.go
+++ b/drivers/middleware/gin/options.go
@@ -51,9 +51,9 @@ func DefaultLimitReachedHandler(c *gin.Context) {
 type KeyGetter func(c *gin.Context) string
 
 // WithKeyGetter will configure the Middleware to use the given KeyGetter.
-func WithKeyGetter(KeyGetter KeyGetter) Option {
+func WithKeyGetter(handler KeyGetter) Option {
 	return option(func(middleware *Middleware) {
-		middleware.KeyGetter = KeyGetter
+		middleware.KeyGetter = handler
 	})
 }
 
@@ -63,9 +63,9 @@ func DefaultKeyGetter(c *gin.Context) string {
 	return c.ClientIP()
 }
 
-// WithExcludedKey will configure the Middleware to use the given function.
-func WithExcludedKey(fn func(string) bool) Option {
+// WithExcludedKey will configure the Middleware to ignore key(s) using the given function.
+func WithExcludedKey(handler func(string) bool) Option {
 	return option(func(middleware *Middleware) {
-		middleware.ExcludedKey = fn
+		middleware.ExcludedKey = handler
 	})
 }

--- a/drivers/middleware/stdlib/options.go
+++ b/drivers/middleware/stdlib/options.go
@@ -44,3 +44,10 @@ func WithLimitReachedHandler(handler LimitReachedHandler) Option {
 func DefaultLimitReachedHandler(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "Limit exceeded", http.StatusTooManyRequests)
 }
+
+// WithExcludedKey will configure the Middleware to ignore key(s) using the given function.
+func WithExcludedKey(handler func(string) bool) Option {
+	return option(func(middleware *Middleware) {
+		middleware.ExcludedKey = handler
+	})
+}


### PR DESCRIPTION
Following #85

Add an option on stdlib and fasthttp middlewares to ignore keys using a function.