### PR TITLE
Fix cache key eviction

### DIFF
--- a/drivers/store/memory/store.go
+++ b/drivers/store/memory/store.go
@@ -2,11 +2,11 @@ package memory
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/ulule/limiter/v3"
 	"github.com/ulule/limiter/v3/drivers/store/common"
-	"github.com/ulule/limiter/v3/internal/bytebuffer"
 )
 
 // Store is the in-memory store.
@@ -35,11 +35,7 @@ func NewStoreWithOptions(options limiter.StoreOptions) limiter.Store {
 
 // Get returns the limit for given identifier.
 func (store *Store) Get(ctx context.Context, key string, rate limiter.Rate) (limiter.Context, error) {
-	buffer := bytebuffer.New()
-	defer buffer.Close()
-	buffer.Concat(store.Prefix, ":", key)
-
-	count, expiration := store.cache.Increment(buffer.String(), 1, rate.Period)
+	count, expiration := store.cache.Increment(store.getCacheKey(key), 1, rate.Period)
 
 	lctx := common.GetContextFromState(time.Now(), rate, expiration, count)
 	return lctx, nil
@@ -47,11 +43,7 @@ func (store *Store) Get(ctx context.Context, key string, rate limiter.Rate) (lim
 
 // Increment increments the limit by given count & returns the new limit value for given identifier.
 func (store *Store) Increment(ctx context.Context, key string, count int64, rate limiter.Rate) (limiter.Context, error) {
-	buffer := bytebuffer.New()
-	defer buffer.Close()
-	buffer.Concat(store.Prefix, ":", key)
-
-	newCount, expiration := store.cache.Increment(buffer.String(), count, rate.Period)
+	newCount, expiration := store.cache.Increment(store.getCacheKey(key), count, rate.Period)
 
 	lctx := common.GetContextFromState(time.Now(), rate, expiration, newCount)
 	return lctx, nil
@@ -59,11 +51,7 @@ func (store *Store) Increment(ctx context.Context, key string, count int64, rate
 
 // Peek returns the limit for given identifier, without modification on current values.
 func (store *Store) Peek(ctx context.Context, key string, rate limiter.Rate) (limiter.Context, error) {
-	buffer := bytebuffer.New()
-	defer buffer.Close()
-	buffer.Concat(store.Prefix, ":", key)
-
-	count, expiration := store.cache.Get(buffer.String(), rate.Period)
+	count, expiration := store.cache.Get(store.getCacheKey(key), rate.Period)
 
 	lctx := common.GetContextFromState(time.Now(), rate, expiration, count)
 	return lctx, nil
@@ -71,12 +59,17 @@ func (store *Store) Peek(ctx context.Context, key string, rate limiter.Rate) (li
 
 // Reset returns the limit for given identifier.
 func (store *Store) Reset(ctx context.Context, key string, rate limiter.Rate) (limiter.Context, error) {
-	buffer := bytebuffer.New()
-	defer buffer.Close()
-	buffer.Concat(store.Prefix, ":", key)
-
-	count, expiration := store.cache.Reset(buffer.String(), rate.Period)
+	count, expiration := store.cache.Reset(store.getCacheKey(key), rate.Period)
 
 	lctx := common.GetContextFromState(time.Now(), rate, expiration, count)
 	return lctx, nil
+}
+
+// getCacheKey returns the full path for an identifier.
+func (store *Store) getCacheKey(key string) string {
+	buffer := strings.Builder{}
+	buffer.WriteString(store.Prefix)
+	buffer.WriteString(":")
+	buffer.WriteString(key)
+	return buffer.String()
 }


### PR DESCRIPTION
This pull request tries to fix the issue reported by #230

I don't know if it wasn't working from the start or something changed internally in Go runtime, but using internal `bytebuffer` to perform string concatenation without allocation is not working as intended.

On the internal memory cache at a given time _(it seems deterministic)_ the key get evicted resetting the value.
https://github.com/ulule/limiter/blob/master/drivers/store/memory/cache.go#L191-L194

I don't have the energy and motivation to dig this far inside go runtime to understand why.
_(So if you want to contribute to the project and you're reading this, don't hesitate)_
But I'm wondering if the key is not garbage collected inside the sync.Map (or something along those lines) 
resulting in this behavior because I've check the produced slice and string and it doesn't seem to differ _(content, length, capacity)_.

**With this fix, we now have a performance penalty since we do an allocation for the key.**

On the previous version:
```
➤ go test -run=XXX -bench=MemoryStore -benchmem -benchtime=30s .
goos: linux
goarch: amd64
pkg: github.com/ulule/limiter/v3/drivers/store/memory
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkMemoryStoreSequentialAccess-8   	220604082	      165.1 ns/op	      0 B/op	      0 allocs/op
BenchmarkMemoryStoreConcurrentAccess-8   	205891585	      171.8 ns/op	      0 B/op	      0 allocs/op
PASS
ok  	github.com/ulule/limiter/v3/drivers/store/memory	105.946s
```

On the newer version with this fix:
```
➤ go test -run=XXX -bench=MemoryStore -benchmem -benchtime=30s .
goos: linux
goarch: amd64
pkg: github.com/ulule/limiter/v3/drivers/store/memory
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkMemoryStoreSequentialAccess-8   	200741551	      187.1 ns/op	     48 B/op	      1 allocs/op
BenchmarkMemoryStoreConcurrentAccess-8   	148522920	      248.3 ns/op	     48 B/op	      1 allocs/op
PASS
ok  	github.com/ulule/limiter/v3/drivers/store/memory	117.020s
```